### PR TITLE
More robust handling of creation delays

### DIFF
--- a/tests/registry.spec.ts
+++ b/tests/registry.spec.ts
@@ -102,9 +102,12 @@ test('create a registry instance create an artifact and delete everything', asyn
   const uploadButtonLocator = page
     .getByText('Upload artifact', { exact: true })
     .first();
-  
-  await expect(uploadButtonLocator).toBeEnabled()
-    .catch(err => { page.getByText('Reload page', { exact: true }).first().click(); });
+
+  await expect(uploadButtonLocator)
+    .toBeEnabled()
+    .catch((err) => {
+      page.getByText('Reload page', { exact: true }).first().click();
+    });
 
   await expect(uploadButtonLocator).toBeEnabled({ timeout: 10000 });
   await uploadButtonLocator.click();

--- a/tests/registry.spec.ts
+++ b/tests/registry.spec.ts
@@ -102,7 +102,11 @@ test('create a registry instance create an artifact and delete everything', asyn
   const uploadButtonLocator = page
     .getByText('Upload artifact', { exact: true })
     .first();
-  await expect(uploadButtonLocator).toBeEnabled();
+  
+  await expect(uploadButtonLocator).toBeEnabled()
+    .catch(err => { page.getByText('Reload page', { exact: true }).first().click(); });
+
+  await expect(uploadButtonLocator).toBeEnabled({ timeout: 10000 });
   await uploadButtonLocator.click();
 
   const artifactContent = fs.readFileSync('./resources/petstore.yaml', {


### PR DESCRIPTION
This should serve as a one-time "page reload" if the artifact creation is taking too much.

Based on this data:
https://github.com/Apicurio/apicurio-registry-e2e-operate-first/actions/runs/3328642982

cc. @riccardo-forina